### PR TITLE
Fix/module-not-found-on-vercel

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React from "react";
-import "xp.css/dist/xp.css";
+// import "xp.css/dist/xp.css";
 
 export default function Home() {
   const [count, setCount] = React.useState(0);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React from "react";
-// import "xp.css/dist/xp.css";
+import "xp.css/dist/xp.css";
 
 export default function Home() {
   const [count, setCount] = React.useState(0);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React from "react";
-import "xp.css/dist/xp.css";
+import "xp.css/dist/XP.css";
 
 export default function Home() {
   const [count, setCount] = React.useState(0);


### PR DESCRIPTION
XP.cssがローカルでは動くのにVercelのデプロイに失敗する問題を解決した。
import文のcssファイル名が小文字になっていたのが原因だった。